### PR TITLE
Ensure all files in docs are part of the sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include LICENSE
 include README.rst
 include requirements
 include test
-include docs
+recursive-include docs *
 include examples/*.py
 include man/pycallgraph.1


### PR DESCRIPTION
With the current MANIFEST.in the scripts for generating examples and
documentation are not actually included in the sdist.  This ensures the
documentation and example sources are included.
