### PR TITLE
Fix graphviz output format setting

### DIFF
--- a/pycallgraph/output/graphviz.py
+++ b/pycallgraph/output/graphviz.py
@@ -45,6 +45,7 @@ class GraphvizOutput(Output):
 
         subparser.add_argument(
             '-f', '--output-format', type=str, default=defaults.output_type,
+            dest='output_type',
             help='Image format to produce, e.g. png, ps, dot, etc. '
             'See http://www.graphviz.org/doc/info/output.html for more.',
         )


### PR DESCRIPTION
Setting graphivz output format is broken: -f / --output-format is ignored. This is because self.output_format is adjusted internally, not output_type. The fix is to set "dest" property of the corresponding argument.
