### PR TITLE
Fixed bug where time taken by recursive calls are added to the cumulative time.

### DIFF
--- a/pycallgraph/tracer.py
+++ b/pycallgraph/tracer.py
@@ -241,6 +241,8 @@ class TraceProcessor(Thread):
 
                 if self.call_stack_timer:
                     start_time = self.call_stack_timer.pop(-1)
+                    if full_name in self.call_stack:
+                        start_time = None
                 else:
                     start_time = None
 


### PR DESCRIPTION
The time taken by recursive calls to a function are added to the cumulative time of the outermost call to that function. Thus, the final cumulative time value for that function exceeds the time spent in that function. This change fixes that problem.

Edit:
Note: The "cumulative time" terminology is from cProfile. What I mean by that is simply the total time spent inside the function.
