### PR TITLE
specify the variable dest as output_type specifically

### DIFF
--- a/pycallgraph/output/graphviz.py
+++ b/pycallgraph/output/graphviz.py
@@ -45,6 +45,7 @@ class GraphvizOutput(Output):
 
         subparser.add_argument(
             '-f', '--output-format', type=str, default=defaults.output_type,
+            dest='output_type',
             help='Image format to produce, e.g. png, ps, dot, etc. '
             'See http://www.graphviz.org/doc/info/output.html for more.',
         )


### PR DESCRIPTION
The default is output_format, which won't be used, it's a bug.

I noticed this bug has already been fixed in develop branch. You probably want to update the package on pip.

I found this bug when executing
```
 pycallgraph graphviz -o aaa.svg -f svg -- some command
```
The command generated to create graph is 
```
pycallgraph.exceptions.PyCallGraphException: The command "dot -Tpng -oaaa.svg /tmp/tmpqhkCxC" failed with error code 256.
```