### PR TITLE
Allow passing in absolute path for GraphvizOutput.tool

### DIFF
--- a/pycallgraph/output/output.py
+++ b/pycallgraph/output/output.py
@@ -90,6 +90,9 @@ class Output(object):
         raise NotImplementedError('done')
 
     def ensure_binary(self, cmd):
+        if os.path.isfile(cmd) and os.access(cmd, os.X_OK):
+            return
+
         if find_executable(cmd):
             return
 


### PR DESCRIPTION
There are times where it's not convenient to add graphviz to the system path, this allows me to set the tool to a full path the the dot executable or similar.
