### PR TITLE
Update .travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
  - sudo apt-get install -qq graphviz
 
 install:
- - "pip install -r requirements/development.txt --use-mirrors"
+ - "pip install -r requirements/development.txt"
  - "if [[ $TRAVIS_PYTHON_VERSION == '3.3' ]] || [[ $TRAVIS_PYTHON_VERSION == '3.4' ]] || [[ $TRAVIS_PYTHON_VERSION == 'nightly' ]]; then make 2to3; fi"
 
 script:


### PR DESCRIPTION
`--use-mirrors` was removed as a `pip` option (https://github.com/pypa/pip/pull/1098)