### PR TITLE
fix(build,#119,#155): fix Windows installation by using setuptools-entry-points

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev"
   - "pypy"
 # pytest does not support python 3.5
 # https://bitbucket.org/pytest-dev/pytest/pull-request/296/astcall-signature-changed-on-35

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   allow_failures:
     - python:
        - "pypy"
+       - '3.7-dev'  # Due to PyYAML (from `coveralls`)
     - python:
        - "nigthly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,13 @@
-language:
- - python
+language: python
 
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
-  - "pypy"
-# pytest does not support python 3.5
-# https://bitbucket.org/pytest-dev/pytest/pull-request/296/astcall-signature-changed-on-35
-# - "nightly"
-
-matrix:
-  allow_failures:
-    - python:
-       - "pypy"
-       - '3.7-dev'  # Due to PyYAML (from `coveralls`)
-    - python:
-       - "nigthly"
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  #- 3.7-dev
+  - pypy
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 
 	flake8 --exclude=__init__.py,memory_profiler.py pycallgraph
 	flake8 --ignore=F403 test
-	flake8 examples
+	flake8 examples --exclude=all.py
 
 doc:
 	cd docs/examples && ./generate.py

--- a/examples/gephi/basic.py
+++ b/examples/gephi/basic.py
@@ -34,7 +34,7 @@ def main():
 
     with PyCallGraph(output=gephi):
         person = Person()
-        for a in xrange(10):
+        for a in range(10):
             person.add_banana(Banana())
         person.eat_bananas()
 

--- a/examples/graphviz/basic.py
+++ b/examples/graphviz/basic.py
@@ -34,7 +34,7 @@ def main():
 
     with PyCallGraph(output=graphviz):
         person = Person()
-        for a in xrange(10):
+        for a in range(10):
             person.add_banana(Banana())
         person.eat_bananas()
 

--- a/examples/graphviz/example_with_submodules/example_with_submodules.py
+++ b/examples/graphviz/example_with_submodules/example_with_submodules.py
@@ -9,5 +9,6 @@ def main():
     s2 = SubmoduleTwo()
     s2.report()
 
+
 if __name__ == "__main__":
     main()

--- a/examples/graphviz/recursive.py
+++ b/examples/graphviz/recursive.py
@@ -17,7 +17,7 @@ def main():
     graphviz.output_file = 'recursive.png'
 
     with PyCallGraph(output=graphviz):
-        for a in xrange(1, 10):
+        for a in range(1, 10):
             factorial(a)
 
 

--- a/examples/graphviz/recursive.py
+++ b/examples/graphviz/recursive.py
@@ -20,5 +20,6 @@ def main():
         for a in xrange(1, 10):
             factorial(a)
 
+
 if __name__ == '__main__':
     main()

--- a/examples/graphviz/regexp.py
+++ b/examples/graphviz/regexp.py
@@ -15,11 +15,11 @@ def main():
     config = Config(include_stdlib=True)
 
     with PyCallGraph(output=graphviz, config=config):
-        reo = compile()
+        reo = compile_regex()
         match(reo)
 
 
-def compile():
+def compile_regex():
     return re.compile('^[abetors]*$')
 
 
@@ -40,6 +40,7 @@ def words():
         'abrasive',
         'abrasives',
     ]
+
 
 if __name__ == '__main__':
     main()

--- a/pycallgraph/__main__.py
+++ b/pycallgraph/__main__.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+pycallgraph
+This script is the command line interface to the pycallgraph Python library.
+
+See http://pycallgraph.slowchop.com/ for more information.
+"""
+
+
+def main():
+    import pycallgraph
+
+    config = pycallgraph.Config()
+    config.parse_args()
+    config.strip_argv()
+
+    globals()['__file__'] = config.command
+
+    file_content = open(config.command).read()
+
+    with pycallgraph.PyCallGraph(config=config):
+        exec(file_content)
+
+
+if __name__ == '__main__':
+    # Pep366 must always be the 1st thing to run.
+    if not globals().get('__package__'):
+        __package__ = "polyversion"  # noqa: A001 F841 @ReservedAssignment
+
+    main()

--- a/pycallgraph/config.py
+++ b/pycallgraph/config.py
@@ -1,9 +1,15 @@
 import argparse
+import operator
 import sys
 
 from .output import outputters
 from .globbing_filter import GlobbingFilter
 from .grouper import Grouper
+
+
+iteritems = operator.methodcaller('iteritems'
+                                  if sys.version_info < (3, ) else
+                                  'items')
 
 
 class Config(object):
@@ -38,7 +44,7 @@ class Config(object):
         self.did_init = True
 
         # Update the defaults with anything from kwargs
-        [setattr(self, k, v) for k, v in kwargs.iteritems()]
+        [setattr(self, k, v) for k, v in iteritems(kwargs)]
 
         self.create_parser()
 

--- a/pycallgraph/output/graphviz.py
+++ b/pycallgraph/output/graphviz.py
@@ -1,7 +1,9 @@
 from __future__ import division
 
 import tempfile
+import operator
 import os
+import sys
 import textwrap
 import subprocess as sub
 
@@ -9,6 +11,11 @@ from ..metadata import __version__
 from ..exceptions import PyCallGraphException
 from ..color import Color
 from .output import Output
+
+
+iteritems = operator.methodcaller('iteritems'
+                                  if sys.version_info < (3, ) else
+                                  'items')
 
 
 class GraphvizOutput(Output):
@@ -151,7 +158,7 @@ class GraphvizOutput(Output):
 
     def attrs_from_dict(self, d):
         output = []
-        for attr, val in d.iteritems():
+        for attr, val in iteritems(d):
             output.append('%s = "%s"' % (attr, val))
         return ', '.join(output)
 
@@ -167,7 +174,7 @@ class GraphvizOutput(Output):
 
     def generate_attributes(self):
         output = []
-        for section, attrs in self.graph_attributes.iteritems():
+        for section, attrs in iteritems(self.graph_attributes):
             output.append('{0} [ {1} ];'.format(
                 section, self.attrs_from_dict(attrs),
             ))

--- a/pycallgraph/output/output.py
+++ b/pycallgraph/output/output.py
@@ -1,9 +1,15 @@
-import re
+import operator
 import os
+import re
+import sys
 from distutils.spawn import find_executable
 
 from ..exceptions import PyCallGraphException
 from ..color import Color
+
+iteritems = operator.methodcaller('iteritems'
+                                  if sys.version_info < (3, ) else
+                                  'items')
 
 
 class Output(object):
@@ -16,14 +22,14 @@ class Output(object):
         self.edge_label_func = self.edge_label
 
         # Update the defaults with anything from kwargs
-        [setattr(self, k, v) for k, v in kwargs.iteritems()]
+        [setattr(self, k, v) for k, v in iteritems(kwargs)]
 
     def set_config(self, config):
         '''
         This is a quick hack to move the config variables set in Config into
         the output module config variables.
         '''
-        for k, v in config.__dict__.iteritems():
+        for k, v in iteritems(config.__dict__):
             if hasattr(self, k) and \
                     callable(getattr(self, k)):
                 continue

--- a/pycallgraph/output/output.py
+++ b/pycallgraph/output/output.py
@@ -116,7 +116,7 @@ class Output(object):
         self.processor.config.log_debug(text)
 
     @classmethod
-    def add_output_file(cls, subparser, defaults, help):
+    def add_output_file(cls, subparser, defaults, help):  # noqa: A002
         subparser.add_argument(
             '-o', '--output-file', type=str, default=defaults.output_file,
             help=help,

--- a/pycallgraph/pycallgraph.py
+++ b/pycallgraph/pycallgraph.py
@@ -33,7 +33,7 @@ class PyCallGraph(object):
     def __enter__(self):
         self.start()
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type, value, traceback):  # noqa: A002
         self.done()
 
     def get_tracer_class(self):

--- a/pycallgraph/tracer.py
+++ b/pycallgraph/tracer.py
@@ -1,8 +1,9 @@
 from __future__ import division
 
 import inspect
-import sys
+import operator
 import os
+import sys
 import time
 from distutils import sysconfig
 from collections import defaultdict
@@ -13,6 +14,11 @@ except ImportError:
     from queue import Queue, Empty
 
 from .util import Util
+
+
+iteritems = operator.methodcaller('iteritems'
+                                  if sys.version_info < (3, ) else
+                                  'items')
 
 
 class SyncronousTracer(object):
@@ -294,7 +300,7 @@ class TraceProcessor(Thread):
         grp = defaultdict(list)
         for node in self.nodes():
             grp[node.group].append(node)
-        for g in grp.iteritems():
+        for g in iteritems(grp):
             yield g
 
     def stat_group_from_func(self, func, calls):
@@ -312,14 +318,14 @@ class TraceProcessor(Thread):
         return stat_group
 
     def nodes(self):
-        for func, calls in self.func_count.iteritems():
+        for func, calls in iteritems(self.func_count):
             yield self.stat_group_from_func(func, calls)
 
     def edges(self):
-        for src_func, dests in self.call_dict.iteritems():
+        for src_func, dests in iteritems(self.call_dict):
             if not src_func:
                 continue
-            for dst_func, calls in dests.iteritems():
+            for dst_func, calls in iteritems(dests):
                 edge = self.stat_group_from_func(dst_func, calls)
                 edge.src_func = src_func
                 edge.dst_func = dst_func

--- a/pycallgraph/tracer.py
+++ b/pycallgraph/tracer.py
@@ -372,4 +372,5 @@ def simple_memoize(callable_object):
 
     return wrapper
 
+
 inspect.getmodule = simple_memoize(inspect.getmodule)

--- a/scripts/pycallgraph
+++ b/scripts/pycallgraph
@@ -4,6 +4,14 @@ pycallgraph
 This script is the command line interface to the pycallgraph Python library.
 
 See http://pycallgraph.slowchop.com/ for more information.
+
+.. deprecated:: > 1.0.1
+    Code here moved to :func:`pycallgraph.__main__.main()`
+    and now using setuptools console-script entry-points,
+    to properly install on Windows.
+    
+    - See https://github.com/gak/pycallgraph/issues/119
+    - See https://github.com/gak/pycallgraph/issues/155
 """
 import sys
 import os

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
+## FIXME: importing my-package may fail if dependent projects
+#  from :mod:`./pycallgraph/__init__.py` are not installed yet at this stage!
 import pycallgraph
 
 
@@ -41,7 +43,8 @@ setup(
     license=open('LICENSE').read(),
     url=pycallgraph.__url__,
     packages=['pycallgraph', 'pycallgraph.output'],
-    scripts=['scripts/pycallgraph'],
+    entry_points={
+        'console_scripts': ['pycallgraph = pycallgraph.__main__:main']},
     data_files=data_files,
     use_2to3=True,
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-from os import path
-from setuptools import setup
 import sys
 
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
 import pycallgraph
+
 
 # Only install the man page if the correct directory exists
 # XXX: Commented because easy_install doesn't like it
@@ -15,8 +15,8 @@ import pycallgraph
 #    data_files=[['/usr/share/man/man1/', ['man/pycallgraph.1']]]
 #else:
 #    data_files=None
+data_files = None
 
-data_files=None
 
 class PyTest(TestCommand):
 
@@ -29,6 +29,7 @@ class PyTest(TestCommand):
         import pytest
         errno = pytest.main(self.test_args)
         sys.exit(errno)
+
 
 setup(
     name='pycallgraph',
@@ -45,15 +46,15 @@ setup(
     use_2to3=True,
 
     # TODO: Update download_url
-    download_url =
-    'http://pycallgraph.slowchop.com/files/download/pycallgraph-%s.tar.gz' % \
-        pycallgraph.__version__,
+    download_url=
+    'http://pycallgraph.slowchop.com/files/download/pycallgraph-%s.tar.gz' %
+    pycallgraph.__version__,
 
     # Testing
     tests_require=['pytest'],
-    cmdclass = {'test': PyTest},
+    cmdclass={'test': PyTest},
 
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License (GPL)',
@@ -68,4 +69,3 @@ setup(
         'Topic :: Software Development :: Debuggers',
     ],
 )
-

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
+from pycallgraph import PyCallGraph, Config
 import tempfile
 
-from helpers import *
+import pytest
 
 
 @pytest.fixture(scope='module')

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,13 +1,6 @@
 # flake8: noqa
 import time
 
-import pytest
-
-import fix_path
-from pycallgraph import *
-from pycallgraph.tracer import *
-from pycallgraph.output import *
-
 
 def wait_100ms():
     time.sleep(0.1)

--- a/test/test_color.py
+++ b/test/test_color.py
@@ -1,4 +1,6 @@
-from helpers import *
+from pycallgraph import ColorException, Color
+
+import pytest
 
 
 def test_bad_range():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,4 +1,4 @@
-from helpers import *
+from pycallgraph.config import Config
 
 
 def test_init():

--- a/test/test_gephi.py
+++ b/test/test_gephi.py
@@ -1,5 +1,10 @@
-from helpers import *
-from calls import *
+from pycallgraph import PyCallGraph
+from pycallgraph.output.gephi import GephiOutput
+import os
+
+import pytest
+
+from calls import one_nop
 
 
 @pytest.fixture

--- a/test/test_graphviz.py
+++ b/test/test_graphviz.py
@@ -1,5 +1,10 @@
-from helpers import *
-from calls import *
+from pycallgraph.output.graphviz import GraphvizOutput
+from pycallgraph.pycallgraph import PyCallGraph
+import os
+
+import pytest
+
+from calls import one_nop
 
 
 @pytest.fixture

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,4 +1,5 @@
-from helpers import *
+from pycallgraph import Config
+from pycallgraph.output import Output
 
 
 def test_set_config():

--- a/test/test_pycallgraph.py
+++ b/test/test_pycallgraph.py
@@ -1,4 +1,7 @@
-from helpers import *
+from pycallgraph.exceptions import PyCallGraphException
+from pycallgraph.tracer import AsyncronousTracer, SyncronousTracer
+
+import pytest
 
 
 def test_start_no_outputs(pycg):

--- a/test/test_script.py
+++ b/test/test_script.py
@@ -1,7 +1,5 @@
 import subprocess
 
-from helpers import *
-
 
 def execute(arguments):
     command = 'PYTHONPATH=. scripts/pycallgraph ' + arguments

--- a/test/test_trace_processor.py
+++ b/test/test_trace_processor.py
@@ -1,9 +1,11 @@
+from pycallgraph.tracer import TraceProcessor
 import re
 import sys
 
-from helpers import *
-import calls
-from pycallgraph.tracer import TraceProcessor
+import pytest
+
+from pycallgraph import Config
+from calls import one_nop, nop
 
 
 @pytest.fixture
@@ -20,7 +22,7 @@ def test_empty(trace_processor):
 
 def test_nop(trace_processor):
     sys.settrace(trace_processor.process)
-    calls.nop()
+    nop()
     sys.settrace(None)
 
     assert trace_processor.call_dict == {
@@ -32,7 +34,7 @@ def test_nop(trace_processor):
 
 def test_one_nop(trace_processor):
     sys.settrace(trace_processor.process)
-    calls.one_nop()
+    one_nop()
     sys.settrace(None)
 
     assert trace_processor.call_dict == {
@@ -45,7 +47,7 @@ def stdlib_trace(trace_processor, include_stdlib):
     trace_processor.config = Config(include_stdlib=include_stdlib)
     sys.settrace(trace_processor.process)
     re.match("asdf", "asdf")
-    calls.one_nop()
+    one_nop()
     sys.settrace(None)
     return trace_processor.call_dict
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,4 +1,4 @@
-from helpers import *
+from pycallgraph.util import Util
 
 
 def test_human_readable_biyte():


### PR DESCRIPTION
...instead of problematic `scripts` setup.py keyword.

Note that this the `console_scripts` *setuptools* entry-point is is now the officially "blessed" way to generated executable scripts:
  https://packaging.python.org/guides/distributing-packages-using-setuptools/#scripts